### PR TITLE
Add more ways to find hidapi shared library.

### DIFF
--- a/hidapi/hidapi.py
+++ b/hidapi/hidapi.py
@@ -154,7 +154,9 @@ def __load_hidapi():
 
     if __hidapi is None:
         # Search for the hidapi library.
-        __libpath = find_library('hidapi')
+        __libpath = find_library('hidapi') or\
+                    find_library('hidapi-libusb') or\
+                    find_library('hidapi-hidraw')
         if __libpath is None:
             raise RuntimeError('Could not find the hidapi shared library.')
 


### PR DESCRIPTION
The Arch package for hidapi installs two libraries: `hidapi-libusb` and `hidapi-hidraw`. There is no library just named `hidapi`, so the search was failing. This change searches for these libraries if it can't find the `hidapi` shared library.